### PR TITLE
Add long description to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,17 @@
 
 """Setup ACAPI package."""
 
+import os
 from setuptools import setup
+
+with open(os.path.join(os.path.dirname(__name__), 'README.rst')) as f:
+    long_description = f.read()
 
 setup(
     name='acapi',
     version='0.4.3',
     description='Acquia Cloud API client.',
+    long_description=long_description,
     author='Dave Hall',
     author_email='me@davehall.com.au',
     url='http://github.com/skwashd/python-acquia-cloud',


### PR DESCRIPTION
There is a reason to add a long description to the project, because there is no any documentation for `acapi`in PyPi, except a short description that contains only project name. Taking into account that PyPi is on the top of Google search, so it would be helpful to have such kind of documentation in PyPi.